### PR TITLE
[Android-LeapChat] Update SDK version and add model downloader example

### DIFF
--- a/Android/LeapChat/README.md
+++ b/Android/LeapChat/README.md
@@ -3,6 +3,7 @@ Example Chat App for LeapSDK
 This is a simple chat app for LeapSDK in Android to illustrate how to use LeapSDK. The UI is implemented with [Jetpack Compose](https://developer.android.com/develop/ui/compose/documentation).
 
 Almost all logic interacting with LeapSDK is in [MainActivity.kt](app/src/main/java/ai/liquid/leapchat/MainActivity.kt). Following features are touched:
+* Downloading a model from Leap Model Library.
 * Loading a model.
 * Generating responses from a conversation.
 * Continue generation from the chat history.

--- a/Android/LeapChat/app/build.gradle.kts
+++ b/Android/LeapChat/app/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.leap.sdk)
     implementation(libs.leap.gson)
+    implementation(libs.leap.model.downloader)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/Android/LeapChat/app/src/main/java/ai/liquid/leapchat/MainActivity.kt
+++ b/Android/LeapChat/app/src/main/java/ai/liquid/leapchat/MainActivity.kt
@@ -132,7 +132,7 @@ class MainActivity : ComponentActivity() {
             bottomBar = {
                 Box {
                     if (modelRunnerInstance == null) {
-                        ModelLoadingIndicator(modelRunnerInstance) {onError, onStatusChange ->
+                        ModelLoadingIndicator(modelRunnerInstance) { onError, onStatusChange ->
                             loadModel(onError, onStatusChange)
                         }
                     } else {
@@ -210,9 +210,18 @@ class MainActivity : ComponentActivity() {
                         LeapModelDownloader.ModelDownloadStatusType.NOT_ON_LOCAL -> {
                             onStatusChange("Model is not downloaded. Waiting for downloading...")
                         }
+
                         LeapModelDownloader.ModelDownloadStatusType.DOWNLOAD_IN_PROGRESS -> {
-                            onStatusChange("Downloading the model: ${String.format("%.2f", status.progress * 100.0)}%")
+                            onStatusChange(
+                                "Downloading the model: ${
+                                    String.format(
+                                        "%.2f",
+                                        status.progress * 100.0
+                                    )
+                                }%"
+                            )
                         }
+
                         LeapModelDownloader.ModelDownloadStatusType.DOWNLOADED -> {
                             isModelAvailable = true
                         }
@@ -351,7 +360,8 @@ class MainActivity : ComponentActivity() {
 
     companion object {
         const val MODEL_SLUG = "lfm2-1.2b"
-        const val QUANTIZATION_SLUG = "lfm2-1.2b-20250710-8da4w" }
+        const val QUANTIZATION_SLUG = "lfm2-1.2b-20250710-8da4w"
+    }
 }
 
 /**
@@ -369,8 +379,8 @@ fun ModelLoadingIndicator(
             loadModelAction({ error ->
                 modelLoadingStatusText =
                     context.getString(R.string.loading_model_fail_content, error.message)
-            },{
-                status ->  modelLoadingStatusText = status
+            }, { status ->
+                modelLoadingStatusText = status
             })
         }
     }

--- a/Android/LeapChat/app/src/main/java/ai/liquid/leapchat/MainActivity.kt
+++ b/Android/LeapChat/app/src/main/java/ai/liquid/leapchat/MainActivity.kt
@@ -7,6 +7,8 @@ import ai.liquid.leap.ModelRunner
 import ai.liquid.leap.gson.LeapGson
 import ai.liquid.leap.gson.registerLeapAdapters
 import ai.liquid.leap.message.ChatMessage
+import ai.liquid.leap.downloader.LeapModelDownloader
+import ai.liquid.leap.downloader.LeapDownloadableModel
 import ai.liquid.leap.message.ChatMessageContent
 import ai.liquid.leap.message.MessageResponse
 import ai.liquid.leapchat.models.ChatMessageDisplayItem
@@ -51,6 +53,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.lifecycleScope
 import com.google.gson.GsonBuilder
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onCompletion
@@ -129,8 +132,8 @@ class MainActivity : ComponentActivity() {
             bottomBar = {
                 Box {
                     if (modelRunnerInstance == null) {
-                        ModelLoadingIndicator(modelRunnerInstance) {
-                            loadModel(it)
+                        ModelLoadingIndicator(modelRunnerInstance) {onError, onStatusChange ->
+                            loadModel(onError, onStatusChange)
                         }
                     } else {
                         Column {
@@ -190,10 +193,36 @@ class MainActivity : ComponentActivity() {
     /**
      * Load the model file.
      */
-    private fun loadModel(onError: (Throwable) -> Unit) {
+    private fun loadModel(onError: (Throwable) -> Unit, onStatusChange: (String) -> Unit) {
         lifecycleScope.launch {
             try {
-                modelRunner.value = LeapClient.loadModel(MODEL_FILE_PATH)
+                val modelToUse = LeapDownloadableModel.resolve(MODEL_SLUG, QUANTIZATION_SLUG)
+                if (modelToUse == null) {
+                    throw RuntimeException("Model $QUANTIZATION_SLUG not found in Leap Model Library!")
+                }
+                val modelDownloader = LeapModelDownloader(this@MainActivity)
+                modelDownloader.requestDownloadModel(modelToUse)
+
+                var isModelAvailable = false
+                while (!isModelAvailable) {
+                    val status = modelDownloader.queryStatus(modelToUse)
+                    when (status.type) {
+                        LeapModelDownloader.ModelDownloadStatusType.NOT_ON_LOCAL -> {
+                            onStatusChange("Model is not downloaded. Waiting for downloading...")
+                        }
+                        LeapModelDownloader.ModelDownloadStatusType.DOWNLOAD_IN_PROGRESS -> {
+                            onStatusChange("Downloading the model: ${String.format("%.2f", status.progress * 100.0)}%")
+                        }
+                        LeapModelDownloader.ModelDownloadStatusType.DOWNLOADED -> {
+                            isModelAvailable = true
+                        }
+                    }
+                    delay(500)
+                }
+                val modelFile = modelDownloader.getModelFile(modelToUse)
+                onStatusChange("Loading the model: ${modelFile.path}")
+
+                modelRunner.value = LeapClient.loadModel(modelFile.path)
             } catch (e: LeapModelLoadingException) {
                 onError(e)
             }
@@ -321,8 +350,8 @@ class MainActivity : ComponentActivity() {
     }
 
     companion object {
-        const val MODEL_FILE_PATH = "/data/local/tmp/liquid/LFM2-1.2B-8da4w_output_8da8w-seq_4096.bundle"
-    }
+        const val MODEL_SLUG = "lfm2-1.2b"
+        const val QUANTIZATION_SLUG = "lfm2-1.2b-20250710-8da4w" }
 }
 
 /**
@@ -331,16 +360,18 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun ModelLoadingIndicator(
     modelRunnerState: ModelRunner?,
-    loadModelAction: (onError: (e: Throwable) -> Unit) -> Unit,
+    loadModelAction: (onError: (e: Throwable) -> Unit, onStatusChange: (String) -> Unit) -> Unit,
 ) {
     val context = LocalContext.current
     var modelLoadingStatusText by remember { mutableStateOf(context.getString(R.string.loading_model_content)) }
     LaunchedEffect(modelRunnerState) {
         if (modelRunnerState == null) {
-            loadModelAction { error ->
+            loadModelAction({ error ->
                 modelLoadingStatusText =
                     context.getString(R.string.loading_model_fail_content, error.message)
-            }
+            },{
+                status ->  modelLoadingStatusText = status
+            })
         }
     }
     Box(Modifier.padding(4.dp).fillMaxSize(1.0f), contentAlignment = Alignment.Center) {

--- a/Android/LeapChat/gradle/libs.versions.toml
+++ b/Android/LeapChat/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-leapSdk = "0.1.0"
+leapSdk = "0.2.0"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2025.06.01"
@@ -32,6 +32,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 gson = { group= "com.google.code.gson", name="gson", version.ref="gson"}
 leap-sdk = { module = "ai.liquid.leap:leap-sdk", version.ref = "leapSdk" }
 leap-gson = { module = "ai.liquid.leap:leap-gson", version.ref = "leapSdk" }
+leap-model-downloader = { module = "ai.liquid.leap:leap-model-downloader", version.ref = "leapSdk"}
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Bump SDK version to v0.2.0 in Android LeapChat app. Also use the model downloader to download the LFM2 1.2B model instead of requiring the users to push models on to the device.