### PR TITLE
Change button order

### DIFF
--- a/Android/LeapChat/app/src/main/java/ai/liquid/leapchat/MainActivity.kt
+++ b/Android/LeapChat/app/src/main/java/ai/liquid/leapchat/MainActivity.kt
@@ -149,14 +149,12 @@ class MainActivity : ComponentActivity() {
                             ) {
                                 Button(
                                     onClick = {
-                                        this@MainActivity.isInGeneration.value = true
-                                        sendText(userInputFieldText)
-                                        userInputFieldText = ""
-                                        chatHistoryFocusRequester.requestFocus()
+                                        conversationHistoryJSONString = null
+                                        this@MainActivity.chatMessageHistory.value = listOf()
                                     },
-                                    enabled = !isInGeneration.value
+                                    enabled = !isInGeneration.value && (conversationHistoryJSONString != null)
                                 ) {
-                                    Text(getString(R.string.send_message_button_label))
+                                    Text(getString(R.string.clean_history_button_label))
                                 }
                                 Button(
                                     onClick = {
@@ -168,12 +166,14 @@ class MainActivity : ComponentActivity() {
                                 }
                                 Button(
                                     onClick = {
-                                        conversationHistoryJSONString = null
-                                        this@MainActivity.chatMessageHistory.value = listOf()
+                                        this@MainActivity.isInGeneration.value = true
+                                        sendText(userInputFieldText)
+                                        userInputFieldText = ""
+                                        chatHistoryFocusRequester.requestFocus()
                                     },
-                                    enabled = !isInGeneration.value && (conversationHistoryJSONString != null)
+                                    enabled = !isInGeneration.value
                                 ) {
-                                    Text(getString(R.string.clean_history_button_label))
+                                    Text(getString(R.string.send_message_button_label))
                                 }
                             }
                         }


### PR DESCRIPTION
prev oder (send, stop, clean) was not ux friendly because I was clicking on "clean" multiple times instead of send - because it was in right most side instead of "send" button.

New order is: clean, stop, send.