### PR TITLE
chore(ci): bump actions/setup-java to v5

### DIFF
--- a/.github/workflows/android-leap-chat-test.yml
+++ b/.github/workflows/android-leap-chat-test.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'


### PR DESCRIPTION
## Summary

- Bumps `actions/setup-java` from `@v4` to `@v5` in `.github/workflows/android-leap-chat-test.yml` — the sole caller in the repo.
- Latest release is v5.2.0; pinning to the major (`@v5`) matches the repo convention (`actions/checkout@v4`, etc.) so future patch/minor updates flow in automatically.

## Test plan

- [ ] CI run on this PR: `Android LeapChat Test` workflow — Set up JDK 21 step succeeds with v5; LeapChat assemble + Firebase Test Lab E2E run pass.